### PR TITLE
Update AuthFunction node RunTime

### DIFF
--- a/webapp.template
+++ b/webapp.template
@@ -515,7 +515,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Handler": "index.handler",
                 "Code": {
                     "ZipFile": {


### PR DESCRIPTION
`nodejs10.x` is the supported by AuthFunction

![Screenshot 2020-01-29 at 14 38 45](https://user-images.githubusercontent.com/10501377/73363418-fcb6d180-42a8-11ea-9e96-f52a25d67c42.png)
![Screenshot 2020-01-29 at 14 42 59](https://user-images.githubusercontent.com/10501377/73363419-fd4f6800-42a8-11ea-8136-c894f727927b.png)
